### PR TITLE
 Add `.env` file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+.env
 *.local
 
 # Editor directories and files


### PR DESCRIPTION
This PR updates the `.gitignore` file to exclude the `.env` file from being made public in this repo. I know in this case there's nothing sensitive, but it's good practice nevertheless  since environment files often contain sensitive data such as API keys, database credentials, or other secrets, and should not be committed to the repository.

**Changes Made:**
- Added `.env` to the `.gitignore` list, placed near other local and environment-specific files for clarity.

**Reasoning:**
- Improves security by preventing accidental commits of environment variables.
- Follows best practices for managing secrets and environment-specific configuration.
